### PR TITLE
Fix for building against pytorch 2.10

### DIFF
--- a/csrc/fused/fused.cu
+++ b/csrc/fused/fused.cu
@@ -15,6 +15,9 @@
  */
 
 #include <torch/csrc/stable/tensor_struct.h>
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
+#include <torch/csrc/stable/tensor_inl.h>
+#endif
 
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/headeronly/util/Exception.h>

--- a/csrc/qattn/qk_int_sv_f16_cuda_sm80.cu
+++ b/csrc/qattn/qk_int_sv_f16_cuda_sm80.cu
@@ -20,6 +20,9 @@
 
 #include <torch/csrc/stable/ops.h>
 #include <torch/csrc/stable/tensor_struct.h>
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
+#include <torch/csrc/stable/tensor_inl.h>
+#endif
 
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/headeronly/util/Exception.h>

--- a/csrc/qattn/qk_int_sv_f8_cuda_sm89.cuh
+++ b/csrc/qattn/qk_int_sv_f8_cuda_sm89.cuh
@@ -20,6 +20,9 @@
 
 #include <torch/csrc/stable/ops.h>
 #include <torch/csrc/stable/tensor_struct.h>
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
+#include <torch/csrc/stable/tensor_inl.h>
+#endif
 
 #include <torch/headeronly/core/ScalarType.h>
 

--- a/csrc/qattn/qk_int_sv_f8_cuda_sm90.cu
+++ b/csrc/qattn/qk_int_sv_f8_cuda_sm90.cu
@@ -21,6 +21,9 @@
 
 #include <torch/csrc/stable/ops.h>
 #include <torch/csrc/stable/tensor_struct.h>
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
+#include <torch/csrc/stable/tensor_inl.h>
+#endif
 
 #include <torch/headeronly/core/ScalarType.h>
 


### PR DESCRIPTION
Was getting linker errors when building against python 2.10 due some changes to the headers that were made. This should fix it.

It's going to be released in a few days, so good to have this available.