### PR TITLE
Keep the native NHD path on gfx12 when smooth_k is off, and widen the raw-Q fp16 value path

### DIFF
--- a/csrc/qattn/attn_gfx12_native.h
+++ b/csrc/qattn/attn_gfx12_native.h
@@ -84,7 +84,8 @@ Tensor sage_fp8_nhd_short_mha_gfx12(
     Tensor value,
     int64_t is_causal,
     double sm_scale,
-    double scale_max);
+    double scale_max,
+    int64_t smooth_k = 1);
 
 Tensor qk_int8_sv_f16_d64_prepare_attn_hnd_gfx12(
     Tensor query,

--- a/csrc/qattn/pybind_gfx12_native.cpp
+++ b/csrc/qattn/pybind_gfx12_native.cpp
@@ -53,7 +53,7 @@ STABLE_TORCH_LIBRARY(sageattention_qattn_gfx12_native, m) {
           ") -> ()");
     m.def("sage_fp8_nhd_short_mha("
             "Tensor query, Tensor key, Tensor value, int is_causal, "
-            "float sm_scale, float scale_max"
+            "float sm_scale, float scale_max, int smooth_k=1"
           ") -> Tensor");
     m.def("qk_int8_sv_f16_d64_prepare_attn_hnd("
             "Tensor query, Tensor key, Tensor value, int is_causal, "

--- a/csrc/qattn/qk_int_sv_gfx12_native.cu
+++ b/csrc/qattn/qk_int_sv_gfx12_native.cu
@@ -770,7 +770,7 @@ __device__ __forceinline__ int32_t pack_f32x4_to_ocp_fp8(
     const float x2,
     const float x3);
 
-template <typename T, int SeqLanes>
+template <typename T, int SeqLanes, bool ComputeMean>
 __global__ void mean_and_fp8_value_nhd_short_kernel(
     const T* __restrict__ key,
     const T* __restrict__ value,
@@ -801,7 +801,9 @@ __global__ void mean_and_fp8_value_nhd_short_kernel(
   if (d < head_dim) {
     for (int64_t s = s_lane; s < seq_len; s += SeqLanes) {
       const int64_t offset = ((b * seq_len + s) * heads + h) * head_dim + d;
-      local_sum += value_to_float(key[offset]);
+      if constexpr (ComputeMean) {
+        local_sum += value_to_float(key[offset]);
+      }
       local_amax = fmaxf(local_amax, fabsf(value_to_float(value[offset])));
     }
   }
@@ -819,12 +821,14 @@ __global__ void mean_and_fp8_value_nhd_short_kernel(
     }
     const int64_t value_d = d_base + tid;
     if (value_d < head_dim) {
-      const float mean = sum / static_cast<float>(seq_len);
       const int64_t mean_offset = (b * heads + h) * head_dim + value_d;
-      if constexpr (std::is_same<T, __half>::value) {
-        key_mean[mean_offset] = value_from_float_half(mean);
-      } else {
-        key_mean[mean_offset] = value_from_float_bfloat16(mean);
+      if constexpr (ComputeMean) {
+        const float mean = sum / static_cast<float>(seq_len);
+        if constexpr (std::is_same<T, __half>::value) {
+          key_mean[mean_offset] = value_from_float_half(mean);
+        } else {
+          key_mean[mean_offset] = value_from_float_bfloat16(mean);
+        }
       }
       const float scale = amax / scale_max;
       scale_tile[tid] = scale == 0.0f ? 0.0f : 1.0f / scale;
@@ -885,7 +889,7 @@ __global__ void mean_and_fp8_value_nhd_short_kernel(
   }
 }
 
-template <typename T, int HeadDim, int NumPackPerThread>
+template <typename T, int HeadDim, int NumPackPerThread, bool SubMean>
 __global__ void quant_k_nhd_fuse_sub_mean_short_kernel(
     const T* __restrict__ key,
     const T* __restrict__ mean,
@@ -916,11 +920,18 @@ __global__ void quant_k_nhd_fuse_sub_mean_short_kernel(
   const int64_t token_base = static_cast<int64_t>(k_block) * BlockSize + local_token;
   const int64_t mean_off = (static_cast<int64_t>(b) * heads + h) * HeadDim + d;
 
-  *reinterpret_cast<uint4*>(&mean_val[0]) =
-      *reinterpret_cast<const uint4*>(mean + mean_off);
+  if constexpr (SubMean) {
+    *reinterpret_cast<uint4*>(&mean_val[0]) =
+        *reinterpret_cast<const uint4*>(mean + mean_off);
 #pragma unroll
-  for (int i = 0; i < PackElems; ++i) {
-    mean_float[i] = value_to_float(mean_val[i]);
+    for (int i = 0; i < PackElems; ++i) {
+      mean_float[i] = value_to_float(mean_val[i]);
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < PackElems; ++i) {
+      mean_float[i] = 0.0f;
+    }
   }
 
   float local_amax = 0.0000001f;
@@ -6134,10 +6145,11 @@ Tensor mean_hnd_gfx12(Tensor input) {
   return mean;
 }
 
-std::vector<Tensor> mean_and_fp8_value_nhd_short_gfx12(
+std::vector<Tensor> mean_and_fp8_value_nhd_short_impl_gfx12(
     Tensor key,
     Tensor value,
-    double scale_max) {
+    double scale_max,
+    bool compute_mean) {
   STD_TORCH_CHECK(key.is_cuda() && value.is_cuda(),
               "gfx12 short NHD mean/value prep expects CUDA/HIP tensors");
   check_same_device(key, value);
@@ -6173,8 +6185,8 @@ std::vector<Tensor> mean_and_fp8_value_nhd_short_gfx12(
   dim3 grid((head_dim + 31) / 32, heads, batch);
   auto [device_guard, stream] = current_hip_stream(key);
 
-#define SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(T_, LANES_) \
-  mean_and_fp8_value_nhd_short_kernel<T_, LANES_><<<grid, block, 0, stream>>>( \
+#define SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(T_, LANES_, MEAN_) \
+  mean_and_fp8_value_nhd_short_kernel<T_, LANES_, MEAN_><<<grid, block, 0, stream>>>( \
       reinterpret_cast<const T_*>(key.data_ptr()), \
       reinterpret_cast<const T_*>(value.data_ptr()), \
       reinterpret_cast<T_*>(key_mean.data_ptr()), \
@@ -6184,20 +6196,43 @@ std::vector<Tensor> mean_and_fp8_value_nhd_short_gfx12(
 
   if (value.scalar_type() == ScalarType::Half) {
     if (head_dim == 64) {
-      SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 32);
+      if (compute_mean) {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 32, true);
+      } else {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 32, false);
+      }
     } else {
-      SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 16);
+      if (compute_mean) {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 16, true);
+      } else {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__half, 16, false);
+      }
     }
   } else {
     if (head_dim == 64) {
-      SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 32);
+      if (compute_mean) {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 32, true);
+      } else {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 32, false);
+      }
     } else {
-      SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 16);
+      if (compute_mean) {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 16, true);
+      } else {
+        SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT(__hip_bfloat16, 16, false);
+      }
     }
   }
 #undef SAGEATTN_LAUNCH_MEAN_FP8_VALUE_SHORT
   hip_kernel_launch_check();
   return {key_mean, output, value_scale};
+}
+
+std::vector<Tensor> mean_and_fp8_value_nhd_short_gfx12(
+    Tensor key,
+    Tensor value,
+    double scale_max) {
+  return mean_and_fp8_value_nhd_short_impl_gfx12(key, value, scale_max, true);
 }
 
 Tensor transpose_value_f16_hnd_gfx12(Tensor value) {
@@ -9122,10 +9157,11 @@ void qk_rawq_int8_sv_f8_scaled_native_attn_gfx12(
       static_cast<int>(key_hnd_layout));
 }
 
-std::vector<Tensor> mean_and_fp8_value_nhd_short_gfx12(
+std::vector<Tensor> mean_and_fp8_value_nhd_short_impl_gfx12(
     Tensor key,
     Tensor value,
-    double scale_max);
+    double scale_max,
+    bool compute_mean);
 
 Tensor sage_fp8_nhd_short_mha_gfx12(
     Tensor query,
@@ -9133,7 +9169,8 @@ Tensor sage_fp8_nhd_short_mha_gfx12(
     Tensor value,
     int64_t is_causal,
     double sm_scale,
-    double scale_max) {
+    double scale_max,
+    int64_t smooth_k) {
   STD_TORCH_CHECK(query.is_cuda() && key.is_cuda() && value.is_cuda(),
               "gfx12 short fp8 wrapper expects CUDA/HIP tensors");
   check_same_device(query, key, value);
@@ -9156,8 +9193,9 @@ Tensor sage_fp8_nhd_short_mha_gfx12(
                   (head_dim == 64 || head_dim == 128),
               "gfx12 fp8 wrapper supports S512/S1024/S2048/S4096/S8192 and D64/D128");
 
+  const bool smooth_key = smooth_k != 0;
   std::vector<Tensor> prep =
-      mean_and_fp8_value_nhd_short_gfx12(key, value, scale_max);
+      mean_and_fp8_value_nhd_short_impl_gfx12(key, value, scale_max, smooth_key);
   Tensor key_mean = prep[0];
   Tensor value_native = prep[1];
   Tensor value_scale = prep[2];
@@ -9167,25 +9205,34 @@ Tensor sage_fp8_nhd_short_mha_gfx12(
 
   const dim3 grid((seq_len + 63) / 64, heads, batch);
   auto [device_guard, stream] = current_hip_stream(key);
+
+#define SAGEATTN_LAUNCH_QUANT_K_SHORT(DIM_, PACK_, SUB_) \
+  quant_k_nhd_fuse_sub_mean_short_kernel<__half, DIM_, PACK_, SUB_> \
+      <<<grid, block, 0, stream>>>( \
+          reinterpret_cast<const __half*>(key.data_ptr()), \
+          reinterpret_cast<const __half*>(key_mean.data_ptr()), \
+          reinterpret_cast<int8_t*>(key_int8.data_ptr()), \
+          reinterpret_cast<float*>(key_scale.data_ptr()), \
+          seq_len, heads)
+
   if (head_dim == 64) {
     constexpr int NumPack = 1;
     dim3 block(64 * (64 / 8) / NumPack);
-    quant_k_nhd_fuse_sub_mean_short_kernel<__half, 64, NumPack><<<grid, block, 0, stream>>>(
-        reinterpret_cast<const __half*>(key.data_ptr()),
-        reinterpret_cast<const __half*>(key_mean.data_ptr()),
-        reinterpret_cast<int8_t*>(key_int8.data_ptr()),
-        reinterpret_cast<float*>(key_scale.data_ptr()),
-        seq_len, heads);
+    if (smooth_key) {
+      SAGEATTN_LAUNCH_QUANT_K_SHORT(64, NumPack, true);
+    } else {
+      SAGEATTN_LAUNCH_QUANT_K_SHORT(64, NumPack, false);
+    }
   } else {
     constexpr int NumPack = 2;
     dim3 block(64 * (128 / 8) / NumPack);
-    quant_k_nhd_fuse_sub_mean_short_kernel<__half, 128, NumPack><<<grid, block, 0, stream>>>(
-        reinterpret_cast<const __half*>(key.data_ptr()),
-        reinterpret_cast<const __half*>(key_mean.data_ptr()),
-        reinterpret_cast<int8_t*>(key_int8.data_ptr()),
-        reinterpret_cast<float*>(key_scale.data_ptr()),
-        seq_len, heads);
+    if (smooth_key) {
+      SAGEATTN_LAUNCH_QUANT_K_SHORT(128, NumPack, true);
+    } else {
+      SAGEATTN_LAUNCH_QUANT_K_SHORT(128, NumPack, false);
+    }
   }
+#undef SAGEATTN_LAUNCH_QUANT_K_SHORT
   hip_kernel_launch_check();
 
   Tensor output = torch::stable::empty_like(query);

--- a/sageattention/gfx12.py
+++ b/sageattention/gfx12.py
@@ -289,9 +289,9 @@ def sageattn_qk_int8_pv_gfx12_native(
     """
     ROCm gfx12 native SageAttention path.
 
-    Supports fixed-length attention. The default smooth-K path follows the
-    CUDA quantization flow; NHD inputs use native NHD quantization to avoid an
-    extra layout conversion when possible.
+    Supports fixed-length attention. The smooth-K path follows the CUDA
+    quantization flow; NHD inputs use native NHD quantization to avoid an
+    extra layout conversion when possible, with or without smooth_k.
 
     Current gfx12 constraints:
     - q, k, and v must be fp16 or bf16.
@@ -399,7 +399,7 @@ def sageattn_qk_int8_pv_gfx12_native(
             out = out if out.dtype == torch.bfloat16 else gfx12_native.convert_f16_to_bf16(out)
         return _with_lse(out)
 
-    if tensor_layout == "NHD" and smooth_k and qk_quant_gran == "per_warp":
+    if tensor_layout == "NHD" and qk_quant_gran == "per_warp":
         q_nhd = q.contiguous()
         k_nhd = k.contiguous()
         v_nhd = v.contiguous()
@@ -436,15 +436,18 @@ def sageattn_qk_int8_pv_gfx12_native(
         if value_dtype == "fp8" and head_dim not in (16, 64, 128, 256):
             raise ValueError("gfx12 fp8 value path currently supports head_dim 16, 64, 128, or 256.")
 
+        # both fused prep kernels compute the key mean internally
         use_gfx12_fp8_nhd_mha_wrapper = (
-            value_dtype == "fp8"
+            smooth_k
+            and value_dtype == "fp8"
             and input_dtype == torch.float16
             and qo_len == kv_len
             and kv_len in (512, 1024, 2048, 4096, 8192)
             and head_dim in (64, 128)
         )
         use_short_nhd_fp8_prep = (
-            value_dtype == "fp8"
+            smooth_k
+            and value_dtype == "fp8"
             and input_dtype == torch.float16
             and qo_len == kv_len
             and kv_len in (512, 1024)
@@ -458,7 +461,10 @@ def sageattn_qk_int8_pv_gfx12_native(
                 return _with_lse(out)
         value_native = None
         value_scale = None
-        if use_short_nhd_fp8_prep:
+        if not smooth_k:
+            k_mean = k_nhd.new_zeros((k_nhd.size(0), 1, k_nhd.size(2), k_nhd.size(3)))
+            k_mean_flat = k_mean.squeeze(1)
+        elif use_short_nhd_fp8_prep:
             k_mean_flat, value_native, value_scale = (
                 gfx12_native.mean_and_fp8_value_nhd_short(
                     k_nhd, v_nhd, float(fp8_value_scale_max)
@@ -533,9 +539,12 @@ def sageattn_qk_int8_pv_gfx12_native(
                 device=k_attn.device,
                 dtype=torch.float32,
             )
-            _quant_fused.quant_per_block_int8_fuse_sub_mean_cuda(
-                k_attn, k_mean_attn.squeeze(2), k_int8, k_scale, 64, 1
-            )
+            if smooth_k:
+                _quant_fused.quant_per_block_int8_fuse_sub_mean_cuda(
+                    k_attn, k_mean_attn.squeeze(2), k_int8, k_scale, 64, 1
+                )
+            else:
+                _quant_fused.quant_per_block_int8_cuda(k_attn, k_int8, k_scale, 64, 1)
         else:
             k_int8 = torch.empty_like(k_nhd, dtype=torch.int8)
             k_scale = torch.empty(
@@ -543,9 +552,12 @@ def sageattn_qk_int8_pv_gfx12_native(
                 device=k_nhd.device,
                 dtype=torch.float32,
             )
-            _quant_fused.quant_per_block_int8_fuse_sub_mean_cuda(
-                k_nhd, k_mean_flat, k_int8, k_scale, 64, 0
-            )
+            if smooth_k:
+                _quant_fused.quant_per_block_int8_fuse_sub_mean_cuda(
+                    k_nhd, k_mean_flat, k_int8, k_scale, 64, 0
+                )
+            else:
+                _quant_fused.quant_per_block_int8_cuda(k_nhd, k_int8, k_scale, 64, 0)
         if value_dtype == "fp8":
             if value_native is None:
                 value_native, value_scale = _gfx12_fp8_value_native(

--- a/sageattention/gfx12.py
+++ b/sageattention/gfx12.py
@@ -59,6 +59,7 @@ def _try_gfx12_fp8_nhd_short_mha(
     is_causal: bool,
     sm_scale: float,
     fp8_value_scale_max: float,
+    smooth_k: bool = True,
 ) -> Optional[torch.Tensor]:
     if not (
         q.is_cuda
@@ -80,7 +81,8 @@ def _try_gfx12_fp8_nhd_short_mha(
 
     gfx12_native = _get_gfx12_native_extension()
     return gfx12_native.sage_fp8_nhd_short_mha(
-        q, k, v, int(is_causal), float(sm_scale), float(fp8_value_scale_max)
+        q, k, v, int(is_causal), float(sm_scale), float(fp8_value_scale_max),
+        int(smooth_k)
     )
 
 
@@ -436,15 +438,14 @@ def sageattn_qk_int8_pv_gfx12_native(
         if value_dtype == "fp8" and head_dim not in (16, 64, 128, 256):
             raise ValueError("gfx12 fp8 value path currently supports head_dim 16, 64, 128, or 256.")
 
-        # both fused prep kernels compute the key mean internally
         use_gfx12_fp8_nhd_mha_wrapper = (
-            smooth_k
-            and value_dtype == "fp8"
+            value_dtype == "fp8"
             and input_dtype == torch.float16
             and qo_len == kv_len
             and kv_len in (512, 1024, 2048, 4096, 8192)
             and head_dim in (64, 128)
         )
+        # mean_and_fp8_value_nhd_short always subtracts the mean, unlike the wrapper
         use_short_nhd_fp8_prep = (
             smooth_k
             and value_dtype == "fp8"
@@ -455,7 +456,8 @@ def sageattn_qk_int8_pv_gfx12_native(
         )
         if use_gfx12_fp8_nhd_mha_wrapper and head_dim_og in (64, 128) and h_qo == h_kv:
             out = _try_gfx12_fp8_nhd_short_mha(
-                q_nhd, k_nhd, v_nhd, is_causal, float(sm_scale), fp8_value_scale_max
+                q_nhd, k_nhd, v_nhd, is_causal, float(sm_scale), fp8_value_scale_max,
+                smooth_k
             )
             if out is not None:
                 return _with_lse(out)
@@ -861,7 +863,6 @@ def gfx12_sageattn(
         not return_lse
         and tensor_layout == "NHD"
         and set(kwargs).issubset(fast_path_keys)
-        and kwargs.get("smooth_k", True)
         and kwargs.get("qk_quant_gran", "per_warp") == "per_warp"
         and not kwargs.get("smooth_v", False)
         and q.is_cuda
@@ -889,7 +890,8 @@ def gfx12_sageattn(
     ):
         fast_sm_scale = float(sm_scale if sm_scale is not None else q.size(-1) ** -0.5)
         out = _try_gfx12_fp8_nhd_short_mha(
-            q, k, v, is_causal, fast_sm_scale, _GFX12_FP8_VALUE_SCALE_MAX_FP32_FP16
+            q, k, v, is_causal, fast_sm_scale, _GFX12_FP8_VALUE_SCALE_MAX_FP32_FP16,
+            kwargs.get("smooth_k", True)
         )
         if out is not None:
             return out

--- a/sageattention/gfx12.py
+++ b/sageattention/gfx12.py
@@ -501,7 +501,6 @@ def sageattn_qk_int8_pv_gfx12_native(
         )
         use_rawq_f16_value = (
             value_dtype == "fp16"
-            and input_dtype == torch.float16
             and head_dim in (64, 128, 256)
             and qk_quant_gran == "per_warp"
             and (

--- a/sageattention/gfx12_native_compile.py
+++ b/sageattention/gfx12_native_compile.py
@@ -12,6 +12,7 @@ def sage_fp8_nhd_short_mha_fake_impl(
     is_causal: int,
     sm_scale: float,
     scale_max: float,
+    smooth_k: int = 1,
 ) -> torch.Tensor:
     return torch.empty_like(query)
 


### PR DESCRIPTION
The native NHD path in `sageattention/gfx12.py` was gated on `smooth_k`, so `smooth_k=False` fell back to HND and paid three contiguous transposes on q/k/v. Only two fused prep kernels actually need smoothing; everything else takes the mean as an argument, and `quant_per_block_int8_cuda` provides the unsmoothed quantizer.

The first commit removes `smooth_k` from the branch condition and uses the plain quantizer when disabled. The second adds a compile-time flag to the two fused prep kernels, so `sage_fp8_nhd_short_mha` supports both modes and skips the key read when smoothing is off. `smooth_k=1` is added as a defaulted argument to preserve schema compatibility. This is the common path since ComfyUI passes `smooth_k=False` on every call it makes.

On gfx1200, comparing two CI wheels built from the same toolchain, ComfyUI's call pattern is 11-60% faster in fp16 and 12-37% in bf16, with the largest gains at short sequences: Flux 1024px (24 heads, L=4096, D=128) goes from 4.79 to 3.36 ms, and Anima (16 heads, L=1024, D=128) from 0.78 to 0.31 ms. `smooth_k=False` was 12-160% slower than `smooth_k=True` and is now at parity. L2 error vs. fp32 SDPA is unchanged, as expected since subtracting the per-head mean shifts all logits equally and softmax cancels the shift.

The third commit drops the `input_dtype == torch.float16` gate on the raw-Q fp16 value path. `qk_rawq_int8_sv_f16_native_attn_gfx12` already accepts bf16 queries and D16/D64/D128/D256, so the gate was stricter than the kernel behind it. Keeping the query raw also beats quantizing it: bf16 with `value_dtype="fp16"` at D=64 goes from 0.252 to 0.221 ms at L=1024 and 1.117 to 1.079 ms at L=4096, with L2 error unchanged. D=128 and D=256 have no before-and-after because they raised.

It also fixes three crash classes: D=256 with `smooth_k=False`, and NHD bf16 with `value_dtype="fp16"` at D=128 and at D=256, the latter having previously hit the D16/D64/D128 limit in `quant_q_nhd_per_warp_gfx12`. A 192-case sweep drops from 44 failures to 0; a separate 144-case sweep covering GQA, cross attention with q_len != kv_len, sequence lengths 77/333/1536/2000 and D=16/72/80/256 also goes from 24 failures to 0. Worst relative L2 error across all of them is 0.0399.

One rebuild gotcha: hipify's incremental pass can leave generated `.hip` files including `utils.cuh` instead of `utils_hip.cuh`, causing `cuda_runtime_api.h` failures. Delete the generated `*.hip` and `*_hip.cuh` files to force a full hipify pass. CI builds from a clean checkout so it will not hit this, but anyone rebuilding locally will.